### PR TITLE
Update camelCase split regex

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,4 @@
+name: test
 on: [push]
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,4 @@
-on:
-  push:
-    tags:
-      - '*'
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,5 +15,4 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: |
-          ls -d */test | cut -f1 -d'/' | grep -v '^node_modules$' | parallel 'cd ./{}; pwd; yarn test'
+        run: yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run tests
+        run: |
+          ls -d */test | cut -f1 -d'/' | grep -v '^node_modules$' | parallel 'cd ./{}; pwd; yarn test'

--- a/lib/casing.js
+++ b/lib/casing.js
@@ -1,5 +1,5 @@
 const camelCaseRegex = /^[a-z][A-Za-z0-9]*$/;
-const camelSplitRegex = /(?=[A-Z])/;
+const camelSplitRegex = /(?=[A-Z])|(?<=[a-z])(?=[0-9])/;
 const snakeCaseRegex = /^[a-z]+(?:_[a-z0-9]+)*$/;
 const snakeCaptureRegex = /_(.)/g;
 

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "url": "https://github.com/cuvva/crpc.git"
   },
   "scripts": {
-		"test": "ava --tap"
-	},
+    "test": "ava --tap"
+  },
   "dependencies": {
     "@cuvva/json-client": "^1.0.1"
   },
   "devDependencies": {
-		"ava": "^3.15.0"
-	},
+    "ava": "^3.15.0"
+  },
   "keywords": [
     "crpc",
     "cuvva",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuvva/crpc",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Simple library for making requests to Cuvva-style RPC APIs",
   "homepage": "https://github.com/cuvva/crpc",
   "bugs": "https://github.com/cuvva/crpc/issues",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,15 @@
     "type": "git",
     "url": "https://github.com/cuvva/crpc.git"
   },
+  "scripts": {
+		"test": "ava --tap"
+	},
   "dependencies": {
     "@cuvva/json-client": "^1.0.1"
   },
+  "devDependencies": {
+		"ava": "^3.15.0"
+	},
   "keywords": [
     "crpc",
     "cuvva",

--- a/test/casing.test.js
+++ b/test/casing.test.js
@@ -1,0 +1,62 @@
+const test = require('ava');
+const { snek, desnek } = require('../lib/casing.js');
+
+test('transform object keys from camelCase to snake_case', t => {
+	const input = {
+        foo: "foo",
+        fooBar: "foo_bar",
+        fooBar100: "foo_bar_100",
+        foo100bars: "foo_100bars",
+        foo200Bars: "foo_200_bars",
+        FooBar: "FooBar",
+        Foo: "Foo",
+        nestedObject: {
+            fooBar: "foo_bar",
+        },
+    };
+
+    const expected = {
+        foo: "foo",
+        foo_bar: "foo_bar",
+        foo_bar_100: "foo_bar_100",
+        foo_100bars: "foo_100bars",
+        foo_200_bars: "foo_200_bars",
+        FooBar: "FooBar",
+        Foo: "Foo",
+        nested_object: {
+            foo_bar: "foo_bar",
+        },
+    };
+
+    t.deepEqual(snek(input), expected)
+});
+
+test('transform object keys from snake_case to camelCase', t => {
+    const input = {
+        foo: "foo",
+        foo_bar: "foo_bar",
+        foo_bar_100: "foo_bar_100",
+        foo_100bars: "foo_100bars",
+        foo_200_bars: "foo_200_bars",
+        FooBar: "FooBar",
+        Foo: "Foo",
+        nested_object: {
+            foo_bar: "foo_bar",
+        },
+    };
+
+    const expected = {
+        foo: "foo",
+        fooBar: "foo_bar",
+        fooBar100: "foo_bar_100",
+        foo100bars: "foo_100bars",
+        foo200Bars: "foo_200_bars",
+        FooBar: "FooBar",
+        Foo: "Foo",
+        nestedObject: {
+            fooBar: "foo_bar",
+        },
+    };
+
+    t.deepEqual(desnek(input), expected)
+});


### PR DESCRIPTION
Update regex for splitting camelCase with alternative for words followed by digits.

Example object key: `distanceToLondonIs100km`
Current result using `snek()`: `distance_to_london_is100km`
Expected result: `distance_to_london_is_100km`