### PR TITLE
browser-hotfix: compile regex at runtime

### DIFF
--- a/lib/casing.js
+++ b/lib/casing.js
@@ -2,6 +2,8 @@ const camelCaseRegex = /^[a-z][A-Za-z0-9]*$/;
 const snakeCaseRegex = /^[a-z]+(?:_[a-z0-9]+)*$/;
 const snakeCaptureRegex = /_(.)/g;
 
+let compiledCamelSplitRegex = null;
+
 exports.snek = snek;
 exports.desnek = desnek;
 
@@ -30,14 +32,15 @@ function snekBrowser(object) {
 }
 
 function snekNode(object) {
-	const camelSplitRegex = /(?=[A-Z])|(?<=[a-z])(?=[0-9])/g;
+	if (!compiledCamelSplitRegex)
+		compiledCamelSplitRegex = new RegExp('(?=[A-Z])|(?<=[a-z])(?=[0-9])', 'g');
 
 	return processKeys(s => {
 		if (!camelCaseRegex.test(s))
 			return s;
 
 		return s
-			.split(camelSplitRegex)
+			.split(compiledCamelSplitRegex)
 			.join('_')
 			.toLowerCase();
 	}, object);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuvva/crpc",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Simple library for making requests to Cuvva-style RPC APIs",
   "homepage": "https://github.com/cuvva/crpc",
   "bugs": "https://github.com/cuvva/crpc/issues",


### PR DESCRIPTION
Regex's are compiled at script-load time, which makes the environment-specific fork pointless. This change compiles the regex only if the detected environment is outside of a browser.